### PR TITLE
Fixed long title in calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
           <li data-date="721">
             <span>Onsdag<span>21</span></span>
             <article>
-              <h1>Bedriftspresentasjon + lønsj med Computas - kl 10:00 - 12 i EL5</h1>
+              <h1>Bedriftspresentasjon + lønsj med Computas</h1>
               <p>Vår samarbeidspartner kommer for å bli bedre kjent med dere som nettopp har startet informatikk. Her blir det muligheter for å bli bedre kjent med bedriften, og med hvordan arbeidslivet er, mens vi spiser lønsj.</p>
 
               <p>Dette skjer i auditorium EL5</p>


### PR DESCRIPTION
1. aug with Computas. Title was too long and ruined formating.
